### PR TITLE
Fixed PHP warning due to non-numeric value

### DIFF
--- a/shortcode-star-rating.php
+++ b/shortcode-star-rating.php
@@ -164,6 +164,7 @@ class ShortcodeStarRating {
 
 		/* Display tyle: rating */
 		if( $type == "rating" ) {
+			$rating = 0;
 			// 小数点以下の最後が0の場合は削除
 			if( is_float( $rating ) ) {
 				$rating = preg_replace( '/\.?0+$/', '', (int)$rating );


### PR DESCRIPTION
- Fixed PHP warning 'A non-numeric value encountered' that was caused by $rating variable not being initialized correctly, when its content is not a float value